### PR TITLE
Convert to entrypoint plugin package; simplify license to EFLv2

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,29 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,23 @@
+
+  Eiffel Forum License, version 2
+
+   1. Permission is hereby granted to use, copy, modify and/or
+      distribute this package, provided that:
+          * copyright notices are retained unchanged,
+          * any distribution of this package, whether modified or not,
+            includes this license text.
+   2. Permission is hereby also granted to distribute binary programs
+      which depend on this package. If the binary program depends on a
+      modified version of this package, you are encouraged to publicly
+      release the modified version of this package.
+
+***********************
+
+THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT WARRANTY. ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHORS BE LIABLE TO ANY PARTY FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THIS PACKAGE.
+
+***********************

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include NEWS
+include COPYING
+include README.md
+
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,5 @@
+## Changelog
+
+### 0.1.0
+
+First proper release of `sopel-http-codes` as a package.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 # sopel-http-codes
-Sopel plugin to look up standard HTTP status codes
+
+Sopel plugin to look up standard HTTP status codes.
 
 
-## Requirements
+## Installing
+
+Releases are hosted on PyPI, so after installing Sopel, all you need is `pip`:
+ 
+```shell
+$ pip install sopel-http-codes
+```
+
+### Requirements
+
 This plugin is written for:
 
-* Python 3.5+
-* Sopel 7.1+
+* Python 3.8+
+* Sopel 8.0+
 
 
-## Usage
+## Using
+
 Commands & arguments:
 
-* `.http <code>`
-  * `<code>`: the HTTP status code to look up
-
-Returns the name of the status code and a brief description of its purpose
-from Python's `http` module.
+`.http <code>`: Returns the name of the given status `<code>` and a brief
+description of its purpose from Python's `http` module, along with a link to an
+image macro showing a cat or dog personifying(?) that status code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools>=63.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+platforms = ["Linux x86, x86-64"]
+
+[tool.setuptools.packages.find]
+include = ["sopel_http_codes", "sopel_http_codes.*"]
+namespaces = false
+
+[tool.setuptools.dynamic]
+readme = { file=["README.md", "NEWS"], content-type="text/markdown" }
+
+[project]
+name = "sopel-http-codes"
+version = "0.1.0"
+description = "Sopel plugin to look up standard HTTP status codes."
+
+authors = [
+  { name="dgw", email="dgw@technobabbl.es" },
+]
+
+license = { text="EFL-2.0" }
+dynamic = ["readme"]
+
+classifiers = [
+  "Intended Audience :: Developers",
+  "Intended Audience :: System Administrators",
+  "License :: Eiffel Forum License (EFL)",
+  "License :: OSI Approved :: Eiffel Forum License",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: Communications :: Chat :: Internet Relay Chat",
+]
+keywords = [
+  "sopel",
+  "plugin",
+  "bot",
+  "irc",
+]
+
+requires-python = ">=3.8, <4"
+dependencies = [
+  "sopel>=8.0",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/dgw/sopel-http-codes"
+"Bug Tracker" = "https://github.com/dgw/sopel-http-codes/issues"
+
+[project.entry-points."sopel.plugins"]
+"http-codes" = "sopel_http_codes.plugin"

--- a/sopel_http_codes/plugin.py
+++ b/sopel_http_codes/plugin.py
@@ -1,10 +1,11 @@
-"""
-http-codes.py - HTTP status code lookup module for Sopel
+"""sopel-http-codes
 
-Copyright 2016-2023, dgw
-Portions based on code by SnoopJ, used with permission.
+Sopel plugin to look up standard HTTP status codes.
 
-Licensed under the GPL v3.0 or later
+Copyright 2016-2024, dgw
+Portions based on code by SnoopJ.
+
+Licensed under the Eiffel Forum License 2.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
~~Just to be safe: @SnoopJ is relicensing this code sorta derived from your GPLv3+ work as EFLv2 OK with you?~~

~~_Note: This plugin has always been GPLv3, according to the Git history. I can't find the code I referenced, though, meaning I can't double check the license SnoopJ used…_~~

~~I would _like_ a more "GitHub-proof" way to include SnoopJ's hypothetical agreement in the final merged history, so it exists somewhere other than a GitHub PR thread that could get lost if I need to move the repo somewhere else. `git commit --signoff` comes to mind, but I don't think that's verifiable. Hmm…~~

**_Also: Configure publishing on PyPI side before merge!_**